### PR TITLE
Fixes for lung example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,14 @@ project(SofaSlicer)
 set(CMAKE_CXX_STANDARD 17)
 add_compile_options(-Wall -Wextra -Wpedantic)
 
-
 # SOFA packages containing our dependencies
 find_package(Sofa.Framework REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
 find_package(Sofa.Component.Topology REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
 find_package(Sofa.Component.StateContainer REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
 find_package(OpenIGTLink REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
+include(${OpenIGTLink_USE_FILE})
 find_package(Threads REQUIRED)
+
 #if(NOT OpenIGTLink_FOUND )
 #        message("SofaSlicer: DEPENDENCY OpenIGTLink NOT FOUND, OpenIGTLink cxxopt...")
 #
@@ -30,7 +31,6 @@ find_package(Threads REQUIRED)
 #                add_subdirectory(${OpenIGTLink_SOURCE_DIR} ${OpenIGTLink_BINARY_DIR})
 #        endif()
 #endif()
-
 
 set(CONFIG_FILES
         src/SofaSlicer/initSofaSlicer.cpp
@@ -53,7 +53,7 @@ file(GLOB_RECURSE SOURCE_FILES
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${SOURCE_FILES})
 target_link_libraries(${PROJECT_NAME} Sofa.Framework Sofa.Component.Topology Sofa.Component.StateContainer OpenIGTLink Threads::Threads)
 ### Dependencies
-include_directories(src)
+include_directories(src ${OpenIGTLink_INCLUDE_DIRS})
 
 
 install(TARGETS

--- a/scenes/LiverCollapse.scn
+++ b/scenes/LiverCollapse.scn
@@ -43,7 +43,7 @@
 <!--    <CollisionResponse name="ContactManager" response="FrictionContactConstraint" responseParams="mu=0.5" />-->
 <!--    <NewProximityIntersection name="Intersection" alarmDistance="0.2" contactDistance="0.02" />-->
 
-    <iGTLinkServer name="iGTLServerSender" sender="true" port="18945"/>
+    <iGTLinkClient name="iGTLClient" sender="true" hostname="127.0.0.1" port=18944 />
 
 
     <Node name="Mesh" >
@@ -57,7 +57,7 @@
         <MechanicalObject name="mstate" template="Vec3f" />
         <ParallelTetrahedronFEMForceField name="FEM"  youngModulus="1.5" poissonRatio="0.45" method="large" />
 <!--        <ConstantForceField totalForce="0 0 -2.5" />-->
-        <iGTLinkMessage name="right-long-mesh-low" iGTLink="@../iGTLServerSender"  template="PolyDataDouble" data="@mstate.position"/>
+        <iGTLinkMessage name="SOFAMesh" iGTLink="@../iGTLClient"  template="PolyDataDouble" data="@mstate.position"/>
 
         <BoxROI template="Vec3" box="0 170 0 -48 80 -300   0 220 0 -30 170 -300" drawBoxes="1" position="@mstate.rest_position" name="FixedROI" computeTriangles="0" computeTetrahedra="0" computeEdges="0" />
         <FixedProjectiveConstraint template="Vec3" name="default6" indices="@FixedROI.indices" />

--- a/src/SofaSlicer/openigtlink/iGTLinkBase.h
+++ b/src/SofaSlicer/openigtlink/iGTLinkBase.h
@@ -2,7 +2,7 @@
 
 #include <map>
 #include <sofa/core/objectmodel/BaseObject.h>
-#include <igtl/igtlClientSocket.h>
+#include <igtlClientSocket.h>
 #include <sofa/simulation/AnimateBeginEvent.h>
 
 

--- a/src/SofaSlicer/openigtlink/iGTLinkClient.h
+++ b/src/SofaSlicer/openigtlink/iGTLinkClient.h
@@ -3,8 +3,8 @@
 
 #include <string>
 
-#include <igtl/igtlOSUtil.h>
-#include <igtl/igtlPointMessage.h>
+#include <igtlOSUtil.h>
+#include <igtlPointMessage.h>
 #include <SofaSlicer/openigtlink/iGTLinkBase.h>
 
 using namespace sofa::core::objectmodel;

--- a/src/SofaSlicer/openigtlink/iGTLinkServer.h
+++ b/src/SofaSlicer/openigtlink/iGTLinkServer.h
@@ -4,9 +4,9 @@
 
 #include <string>
 
-#include <igtl/igtlOSUtil.h>
-#include <igtl/igtlPointMessage.h>
-#include <igtl/igtlServerSocket.h>
+#include <igtlOSUtil.h>
+#include <igtlPointMessage.h>
+#include <igtlServerSocket.h>
 #include <SofaSlicer/openigtlink/iGTLinkBase.h>
 #include <SofaSlicer/openigtlink/iGTLinkMessage.h>
 


### PR DESCRIPTION
These are a set of fixes to streamline the integration with the Slicer-SOFA extension:

  - It enables the use of the OpenIGTLink build tree when building the plugin (it should also work with the install tree).
  - It tweaks the configuration file to match the configuration of the Slicer-SOFA extension